### PR TITLE
Implement Phase 3: User Management

### DIFF
--- a/app/app/users/[id]/edit/page.tsx
+++ b/app/app/users/[id]/edit/page.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useEffect, useState, FormEvent } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { useAuth } from '@/context/AuthContext';
+import { usersApi, User } from '@/lib/api';
+
+export default function EditUserPage() {
+  const { token, user: me } = useAuth();
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+
+  const [form, setForm]     = useState<Partial<User> & { password?: string }>({});
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving]   = useState(false);
+  const [errors, setErrors]   = useState<Record<string, string[]>>({});
+
+  useEffect(() => {
+    if (!token) return;
+    usersApi.get(token, Number(id))
+      .then(u => setForm({
+        name: u.name, username: u.username ?? '', email: u.email,
+        role: u.role, status: u.status,
+        join_at: u.join_at ?? '', monthly_target_count: u.monthly_target_count,
+        extension_number: u.extension_number ?? '',
+      }))
+      .catch(() => router.push('/users'))
+      .finally(() => setLoading(false));
+  }, [token, id, router]);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!token) return;
+    setSaving(true);
+    setErrors({});
+    try {
+      await usersApi.update(token, Number(id), form);
+      router.push(`/users/${id}`);
+    } catch (err: unknown) {
+      const e = err as { errors?: Record<string, string[]>; message?: string };
+      setErrors(e.errors ?? { name: [e.message ?? '更新に失敗しました。'] });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const set = (key: keyof typeof form) => (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) =>
+    setForm(prev => ({ ...prev, [key]: e.target.value }));
+
+  if (loading) return <div className="flex items-center justify-center min-h-screen text-gray-400">読み込み中...</div>;
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-2xl mx-auto p-6">
+        <div className="flex items-center gap-2 text-sm text-gray-500 mb-4">
+          <Link href="/users" className="hover:text-blue-600">ユーザー管理</Link>
+          <span>/</span>
+          <Link href={`/users/${id}`} className="hover:text-blue-600">{form.name}</Link>
+          <span>/</span>
+          <span className="text-gray-800">編集</span>
+        </div>
+
+        <div className="bg-white rounded-xl shadow-sm p-6">
+          <h1 className="text-xl font-bold text-gray-800 mb-6">ユーザー編集</h1>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            {[
+              { label: '氏名 *', key: 'name', type: 'text' },
+              { label: 'ユーザー名', key: 'username', type: 'text' },
+              { label: 'メールアドレス *', key: 'email', type: 'email' },
+              { label: '稼働開始日', key: 'join_at', type: 'date' },
+              { label: '内線番号', key: 'extension_number', type: 'text' },
+            ].map(({ label, key, type }) => (
+              <div key={key}>
+                <label className="block text-sm font-medium text-gray-700 mb-1">{label}</label>
+                <input type={type} value={String(form[key as keyof typeof form] ?? '')} onChange={set(key as keyof typeof form)}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                {errors[key] && <p className="text-red-500 text-xs mt-1">{errors[key][0]}</p>}
+              </div>
+            ))}
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">月次目標数</label>
+              <input type="number" min={0} value={form.monthly_target_count ?? 0}
+                onChange={e => setForm(p => ({ ...p, monthly_target_count: Number(e.target.value) }))}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+            </div>
+
+            {me?.role === 'Admin' && (
+              <>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">権限</label>
+                  <select value={form.role ?? 'IS'} onChange={set('role')}
+                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+                    <option value="Admin">管理者</option>
+                    <option value="Manager">マネージャー</option>
+                    <option value="IS">IS</option>
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">ステータス</label>
+                  <select value={form.status ?? 'onboarding'} onChange={set('status')}
+                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+                    <option value="active">稼働中</option>
+                    <option value="onboarding">オンボーディング</option>
+                    <option value="inactive">非稼働</option>
+                  </select>
+                </div>
+              </>
+            )}
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">新しいパスワード（変更する場合のみ）</label>
+              <input type="password" value={form.password ?? ''} onChange={set('password')}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+              {errors.password && <p className="text-red-500 text-xs mt-1">{errors.password[0]}</p>}
+            </div>
+
+            <div className="flex gap-3 pt-2">
+              <button type="submit" disabled={saving}
+                className="bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold px-4 py-2 rounded-lg transition disabled:opacity-50">
+                {saving ? '更新中...' : '更新する'}
+              </button>
+              <button type="button" onClick={() => router.back()}
+                className="border border-gray-300 hover:bg-gray-50 text-gray-700 text-sm font-semibold px-4 py-2 rounded-lg transition">
+                キャンセル
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/app/users/[id]/page.tsx
+++ b/app/app/users/[id]/page.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { useAuth } from '@/context/AuthContext';
+import { usersApi, User } from '@/lib/api';
+
+const ROLE_LABEL   = { Admin: '管理者', Manager: 'マネージャー', IS: 'IS' } as const;
+const STATUS_LABEL = { active: '稼働中', onboarding: 'オンボーディング', inactive: '非稼働' } as const;
+const STATUS_COLOR = {
+  active: 'bg-green-100 text-green-700',
+  onboarding: 'bg-yellow-100 text-yellow-700',
+  inactive: 'bg-gray-100 text-gray-500',
+} as const;
+
+function Row({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex py-3 border-b border-gray-100 last:border-0">
+      <dt className="w-40 text-sm font-medium text-gray-500 shrink-0">{label}</dt>
+      <dd className="text-sm text-gray-800">{value ?? '—'}</dd>
+    </div>
+  );
+}
+
+export default function UserDetailPage() {
+  const { token, user: me } = useAuth();
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+  const [user, setUser]     = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!token) return;
+    usersApi.get(token, Number(id))
+      .then(setUser)
+      .catch(() => router.push('/users'))
+      .finally(() => setLoading(false));
+  }, [token, id, router]);
+
+  if (loading) return <div className="flex items-center justify-center min-h-screen text-gray-400">読み込み中...</div>;
+  if (!user)   return null;
+
+  const canEdit = me?.role === 'Admin' || me?.role === 'Manager' || me?.id === user.id;
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-2xl mx-auto p-6">
+        <div className="flex items-center gap-2 text-sm text-gray-500 mb-4">
+          <Link href="/users" className="hover:text-blue-600">ユーザー管理</Link>
+          <span>/</span>
+          <span className="text-gray-800">{user.name}</span>
+        </div>
+
+        <div className="bg-white rounded-xl shadow-sm p-6">
+          <div className="flex items-center justify-between mb-6">
+            <div>
+              <h1 className="text-xl font-bold text-gray-800">{user.name}</h1>
+              {user.username && <p className="text-sm text-gray-400">@{user.username}</p>}
+            </div>
+            <span className={`text-xs font-medium px-2 py-1 rounded ${STATUS_COLOR[user.status]}`}>
+              {STATUS_LABEL[user.status]}
+            </span>
+          </div>
+
+          <dl>
+            <Row label="メールアドレス" value={user.email} />
+            <Row label="権限" value={ROLE_LABEL[user.role]} />
+            <Row label="稼働開始日" value={user.join_at} />
+            <Row label="月次目標" value={user.monthly_target_count ? `${user.monthly_target_count} 件` : null} />
+            <Row label="内線番号" value={user.extension_number} />
+          </dl>
+
+          {canEdit && (
+            <div className="mt-6 flex gap-3">
+              <button onClick={() => router.push(`/users/${user.id}/edit`)}
+                className="bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold px-4 py-2 rounded-lg transition">
+                編集
+              </button>
+              <button onClick={() => router.back()}
+                className="border border-gray-300 hover:bg-gray-50 text-gray-700 text-sm font-semibold px-4 py-2 rounded-lg transition">
+                戻る
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/app/users/new/page.tsx
+++ b/app/app/users/new/page.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useState, FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { useAuth } from '@/context/AuthContext';
+import { usersApi } from '@/lib/api';
+
+export default function NewUserPage() {
+  const { token, user: me } = useAuth();
+  const router = useRouter();
+
+  const [form, setForm] = useState({
+    name: '', username: '', email: '', password: '',
+    role: 'IS' as const, status: 'onboarding' as const,
+    join_at: '', monthly_target_count: 0, extension_number: '',
+  });
+  const [errors, setErrors] = useState<Record<string, string[]>>({});
+  const [saving, setSaving] = useState(false);
+
+  if (me?.role !== 'Admin') {
+    router.push('/users');
+    return null;
+  }
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!token) return;
+    setSaving(true);
+    setErrors({});
+    try {
+      const created = await usersApi.create(token, form);
+      router.push(`/users/${created.id}`);
+    } catch (err: unknown) {
+      const e = err as { errors?: Record<string, string[]>; message?: string };
+      setErrors(e.errors ?? { name: [e.message ?? '作成に失敗しました。'] });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const set = (key: keyof typeof form) => (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) =>
+    setForm(prev => ({ ...prev, [key]: e.target.value }));
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-2xl mx-auto p-6">
+        <div className="flex items-center gap-2 text-sm text-gray-500 mb-4">
+          <Link href="/users" className="hover:text-blue-600">ユーザー管理</Link>
+          <span>/</span>
+          <span className="text-gray-800">新規追加</span>
+        </div>
+
+        <div className="bg-white rounded-xl shadow-sm p-6">
+          <h1 className="text-xl font-bold text-gray-800 mb-6">ユーザー追加</h1>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            {[
+              { label: '氏名 *', key: 'name', type: 'text', required: true },
+              { label: 'ユーザー名', key: 'username', type: 'text', required: false },
+              { label: 'メールアドレス *', key: 'email', type: 'email', required: true },
+              { label: 'パスワード *', key: 'password', type: 'password', required: true },
+              { label: '稼働開始日', key: 'join_at', type: 'date', required: false },
+              { label: '内線番号', key: 'extension_number', type: 'text', required: false },
+            ].map(({ label, key, type, required }) => (
+              <div key={key}>
+                <label className="block text-sm font-medium text-gray-700 mb-1">{label}</label>
+                <input type={type} required={required} value={String(form[key as keyof typeof form])} onChange={set(key as keyof typeof form)}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                {errors[key] && <p className="text-red-500 text-xs mt-1">{errors[key][0]}</p>}
+              </div>
+            ))}
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">月次目標数</label>
+              <input type="number" min={0} value={form.monthly_target_count}
+                onChange={e => setForm(p => ({ ...p, monthly_target_count: Number(e.target.value) }))}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">権限 *</label>
+              <select value={form.role} onChange={set('role')}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+                <option value="Admin">管理者</option>
+                <option value="Manager">マネージャー</option>
+                <option value="IS">IS</option>
+              </select>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">ステータス *</label>
+              <select value={form.status} onChange={set('status')}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+                <option value="active">稼働中</option>
+                <option value="onboarding">オンボーディング</option>
+                <option value="inactive">非稼働</option>
+              </select>
+            </div>
+
+            <div className="flex gap-3 pt-2">
+              <button type="submit" disabled={saving}
+                className="bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold px-4 py-2 rounded-lg transition disabled:opacity-50">
+                {saving ? '作成中...' : '追加する'}
+              </button>
+              <button type="button" onClick={() => router.push('/users')}
+                className="border border-gray-300 hover:bg-gray-50 text-gray-700 text-sm font-semibold px-4 py-2 rounded-lg transition">
+                キャンセル
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/app/users/page.tsx
+++ b/app/app/users/page.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/context/AuthContext';
+import { usersApi, User, Role, Status, UserParams } from '@/lib/api';
+
+const ROLE_LABEL: Record<Role, string>     = { Admin: '管理者', Manager: 'マネージャー', IS: 'IS' };
+const STATUS_LABEL: Record<Status, string> = { active: '稼働中', onboarding: 'オンボーディング', inactive: '非稼働' };
+const STATUS_COLOR: Record<Status, string> = {
+  active: 'bg-green-100 text-green-700',
+  onboarding: 'bg-yellow-100 text-yellow-700',
+  inactive: 'bg-gray-100 text-gray-500',
+};
+
+export default function UsersPage() {
+  const { token, user: me } = useAuth();
+  const router = useRouter();
+
+  const [users, setUsers]       = useState<User[]>([]);
+  const [total, setTotal]       = useState(0);
+  const [page, setPage]         = useState(1);
+  const [lastPage, setLastPage] = useState(1);
+  const [loading, setLoading]   = useState(false);
+
+  const [search,  setSearch]  = useState('');
+  const [role,    setRole]    = useState<Role | ''>('');
+  const [status,  setStatus]  = useState<Status | ''>('');
+  const [sortBy,  setSortBy]  = useState('created_at');
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
+
+  const fetchUsers = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    try {
+      const params: UserParams = { page, per_page: 15, sort_by: sortBy, sort_dir: sortDir };
+      if (search) params.search = search;
+      if (role)   params.role   = role;
+      if (status) params.status = status;
+      const res = await usersApi.list(token, params);
+      setUsers(res.data);
+      setTotal(res.total);
+      setLastPage(res.last_page);
+    } finally {
+      setLoading(false);
+    }
+  }, [token, page, search, role, status, sortBy, sortDir]);
+
+  useEffect(() => { fetchUsers(); }, [fetchUsers]);
+
+  const handleSort = (col: string) => {
+    if (sortBy === col) setSortDir(d => (d === 'asc' ? 'desc' : 'asc'));
+    else { setSortBy(col); setSortDir('asc'); }
+    setPage(1);
+  };
+
+  const handleDelete = async (id: number) => {
+    if (!token || !confirm('このユーザーを削除しますか？')) return;
+    await usersApi.delete(token, id);
+    fetchUsers();
+  };
+
+  const SortIcon = ({ col }: { col: string }) =>
+    sortBy === col ? <span className="ml-1">{sortDir === 'asc' ? '↑' : '↓'}</span> : null;
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-6xl mx-auto p-6">
+        <div className="flex items-center justify-between mb-6">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-800">ユーザー管理</h1>
+            <p className="text-sm text-gray-500 mt-1">全 {total} 件</p>
+          </div>
+          {me?.role === 'Admin' && (
+            <Link href="/users/new" className="bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold px-4 py-2 rounded-lg transition">
+              + ユーザー追加
+            </Link>
+          )}
+        </div>
+
+        <div className="bg-white rounded-xl shadow-sm p-4 mb-4 flex flex-wrap gap-3">
+          <input
+            type="text"
+            placeholder="名前・メール・ユーザー名で検索"
+            value={search}
+            onChange={e => { setSearch(e.target.value); setPage(1); }}
+            className="border border-gray-300 rounded-lg px-3 py-2 text-sm flex-1 min-w-48 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          <select value={role} onChange={e => { setRole(e.target.value as Role | ''); setPage(1); }}
+            className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+            <option value="">すべての権限</option>
+            {(Object.entries(ROLE_LABEL) as [Role, string][]).map(([v, l]) => (
+              <option key={v} value={v}>{l}</option>
+            ))}
+          </select>
+          <select value={status} onChange={e => { setStatus(e.target.value as Status | ''); setPage(1); }}
+            className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+            <option value="">すべてのステータス</option>
+            {(Object.entries(STATUS_LABEL) as [Status, string][]).map(([v, l]) => (
+              <option key={v} value={v}>{l}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className="bg-white rounded-xl shadow-sm overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 border-b border-gray-200">
+              <tr>
+                {[['name','氏名'],['email','メールアドレス'],['role','権限'],['status','ステータス'],['join_at','稼働開始日']].map(([col, label]) => (
+                  <th key={col} onClick={() => handleSort(col)}
+                    className="px-4 py-3 text-left font-semibold text-gray-600 cursor-pointer hover:text-gray-900 select-none">
+                    {label}<SortIcon col={col} />
+                  </th>
+                ))}
+                <th className="px-4 py-3 text-left font-semibold text-gray-600">操作</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {loading ? (
+                <tr><td colSpan={6} className="px-4 py-8 text-center text-gray-400">読み込み中...</td></tr>
+              ) : users.length === 0 ? (
+                <tr><td colSpan={6} className="px-4 py-8 text-center text-gray-400">ユーザーが見つかりません</td></tr>
+              ) : users.map(u => (
+                <tr key={u.id} className="hover:bg-gray-50 transition">
+                  <td className="px-4 py-3">
+                    <div className="font-medium text-gray-800">{u.name}</div>
+                    {u.username && <div className="text-xs text-gray-400">@{u.username}</div>}
+                  </td>
+                  <td className="px-4 py-3 text-gray-600">{u.email}</td>
+                  <td className="px-4 py-3">
+                    <span className="text-xs font-medium text-gray-600 bg-gray-100 px-2 py-0.5 rounded">
+                      {ROLE_LABEL[u.role]}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3">
+                    <span className={`text-xs font-medium px-2 py-0.5 rounded ${STATUS_COLOR[u.status]}`}>
+                      {STATUS_LABEL[u.status]}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-gray-600">{u.join_at ?? '—'}</td>
+                  <td className="px-4 py-3">
+                    <div className="flex gap-2">
+                      <button onClick={() => router.push(`/users/${u.id}`)}
+                        className="text-blue-600 hover:underline text-xs">詳細</button>
+                      {(me?.role === 'Admin' || me?.role === 'Manager' || me?.id === u.id) && (
+                        <button onClick={() => router.push(`/users/${u.id}/edit`)}
+                          className="text-gray-600 hover:underline text-xs">編集</button>
+                      )}
+                      {me?.role === 'Admin' && me.id !== u.id && (
+                        <button onClick={() => handleDelete(u.id)}
+                          className="text-red-500 hover:underline text-xs">削除</button>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {lastPage > 1 && (
+          <div className="flex items-center justify-center gap-2 mt-4">
+            <button disabled={page === 1} onClick={() => setPage(p => p - 1)}
+              className="px-3 py-1 text-sm border border-gray-300 rounded disabled:opacity-40 hover:bg-gray-50">
+              前へ
+            </button>
+            <span className="text-sm text-gray-600">{page} / {lastPage}</span>
+            <button disabled={page === lastPage} onClick={() => setPage(p => p + 1)}
+              className="px-3 py-1 text-sm border border-gray-300 rounded disabled:opacity-40 hover:bg-gray-50">
+              次へ
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -14,9 +14,7 @@ async function request<T>(endpoint: string, options: RequestOptions = {}): Promi
     Accept: 'application/json',
   };
 
-  if (token) {
-    headers['Authorization'] = `Bearer ${token}`;
-  }
+  if (token) headers['Authorization'] = `Bearer ${token}`;
 
   const res = await fetch(`${API_BASE_URL}${endpoint}`, {
     method,
@@ -25,13 +23,35 @@ async function request<T>(endpoint: string, options: RequestOptions = {}): Promi
   });
 
   const data = await res.json();
-
   if (!res.ok) {
     throw { status: res.status, errors: data.errors ?? null, message: data.message ?? 'エラーが発生しました。' };
   }
-
   return data as T;
 }
+
+// ---- 型定義 ----
+export type Role   = 'Admin' | 'Manager' | 'IS';
+export type Status = 'active' | 'onboarding' | 'inactive';
+
+export type User = {
+  id: number;
+  name: string;
+  username: string | null;
+  email: string;
+  role: Role;
+  status: Status;
+  join_at: string | null;
+  monthly_target_count: number;
+  extension_number: string | null;
+};
+
+export type PaginatedResponse<T> = {
+  data: T[];
+  current_page: number;
+  last_page: number;
+  per_page: number;
+  total: number;
+};
 
 export type AuthResponse = {
   user: User;
@@ -39,25 +59,43 @@ export type AuthResponse = {
   token_type: string;
 };
 
-export type User = {
-  id: number;
-  name: string;
-  email: string;
+export type UserParams = {
+  search?: string;
+  role?: Role;
+  status?: Status;
+  sort_by?: string;
+  sort_dir?: 'asc' | 'desc';
+  per_page?: number;
+  page?: number;
 };
 
+// ---- 認証 API ----
 export const authApi = {
   register: (data: { name: string; email: string; password: string; password_confirmation: string }) =>
     request<AuthResponse>('/register', { method: 'POST', body: data }),
-
   login: (data: { email: string; password: string }) =>
     request<AuthResponse>('/login', { method: 'POST', body: data }),
+  guestLogin: () => request<AuthResponse>('/guest-login', { method: 'POST' }),
+  logout: (token: string) => request<{ message: string }>('/logout', { method: 'POST', token }),
+  me: (token: string) => request<User>('/user', { token }),
+};
 
-  guestLogin: () =>
-    request<AuthResponse>('/guest-login', { method: 'POST' }),
-
-  logout: (token: string) =>
-    request<{ message: string }>('/logout', { method: 'POST', token }),
-
-  me: (token: string) =>
-    request<User>('/user', { token }),
+// ---- ユーザー管理 API ----
+export const usersApi = {
+  list: (token: string, params: UserParams = {}) => {
+    const qs = new URLSearchParams(
+      Object.entries(params)
+        .filter(([, v]) => v !== undefined && v !== '')
+        .map(([k, v]) => [k, String(v)])
+    ).toString();
+    return request<PaginatedResponse<User>>(`/users${qs ? '?' + qs : ''}`, { token });
+  },
+  get: (token: string, id: number) =>
+    request<User>(`/users/${id}`, { token }),
+  create: (token: string, data: Partial<User> & { password: string }) =>
+    request<User>('/users', { method: 'POST', body: data, token }),
+  update: (token: string, id: number, data: Partial<User> & { password?: string }) =>
+    request<User>(`/users/${id}`, { method: 'PUT', body: data, token }),
+  delete: (token: string, id: number) =>
+    request<{ message: string }>(`/users/${id}`, { method: 'DELETE', token }),
 };

--- a/backend/app/Http/Controllers/Api/UserController.php
+++ b/backend/app/Http/Controllers/Api/UserController.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\User\StoreUserRequest;
+use App\Http\Requests\User\UpdateUserRequest;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class UserController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $query = User::query();
+
+        // 検索
+        if ($search = $request->query('search')) {
+            $query->where(function ($q) use ($search) {
+                $q->where('name', 'like', "%{$search}%")
+                  ->orWhere('email', 'like', "%{$search}%")
+                  ->orWhere('username', 'like', "%{$search}%");
+            });
+        }
+
+        // フィルタリング
+        if ($role = $request->query('role')) {
+            $query->where('role', $role);
+        }
+        if ($status = $request->query('status')) {
+            $query->where('status', $status);
+        }
+
+        // ソート
+        $sortBy  = $request->query('sort_by', 'created_at');
+        $sortDir = $request->query('sort_dir', 'desc');
+        $allowedSorts = ['name', 'email', 'role', 'status', 'join_at', 'created_at'];
+        if (in_array($sortBy, $allowedSorts)) {
+            $query->orderBy($sortBy, $sortDir === 'asc' ? 'asc' : 'desc');
+        }
+
+        $perPage = min((int) $request->query('per_page', 15), 100);
+        $users   = $query->paginate($perPage);
+
+        return response()->json($users);
+    }
+
+    public function store(StoreUserRequest $request): JsonResponse
+    {
+        $user = User::create($request->validated());
+
+        return response()->json($user, 201);
+    }
+
+    public function show(User $user): JsonResponse
+    {
+        return response()->json($user);
+    }
+
+    public function update(UpdateUserRequest $request, User $user): JsonResponse
+    {
+        // Admin 以外は role の変更不可
+        $data = $request->validated();
+        if (! $request->user()?->isAdmin()) {
+            unset($data['role']);
+        }
+
+        $user->update($data);
+
+        return response()->json($user->fresh());
+    }
+
+    public function destroy(Request $request, User $user): JsonResponse
+    {
+        if (! $request->user()?->isAdmin()) {
+            return response()->json(['message' => '権限がありません。'], 403);
+        }
+
+        if ($request->user()->id === $user->id) {
+            return response()->json(['message' => '自分自身は削除できません。'], 422);
+        }
+
+        $user->delete();
+
+        return response()->json(['message' => 'ユーザーを削除しました。']);
+    }
+}

--- a/backend/app/Http/Requests/User/StoreUserRequest.php
+++ b/backend/app/Http/Requests/User/StoreUserRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Requests\User;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreUserRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->isAdmin() ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name'                  => ['required', 'string', 'max:255'],
+            'username'              => ['nullable', 'string', 'max:255', 'unique:users'],
+            'email'                 => ['required', 'string', 'email', 'max:255', 'unique:users'],
+            'password'              => ['required', 'string', 'min:8'],
+            'role'                  => ['required', 'in:Admin,Manager,IS'],
+            'status'                => ['required', 'in:active,onboarding,inactive'],
+            'join_at'               => ['nullable', 'date'],
+            'monthly_target_count'  => ['nullable', 'integer', 'min:0'],
+            'extension_number'      => ['nullable', 'string', 'max:20'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'name.required'     => '氏名は必須です。',
+            'email.required'    => 'メールアドレスは必須です。',
+            'email.unique'      => 'このメールアドレスは既に使用されています。',
+            'password.required' => 'パスワードは必須です。',
+            'password.min'      => 'パスワードは8文字以上で入力してください。',
+            'role.required'     => '権限は必須です。',
+            'role.in'           => '権限の値が不正です。',
+            'status.required'   => 'ステータスは必須です。',
+            'status.in'         => 'ステータスの値が不正です。',
+        ];
+    }
+}

--- a/backend/app/Http/Requests/User/UpdateUserRequest.php
+++ b/backend/app/Http/Requests/User/UpdateUserRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Requests\User;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateUserRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        // Admin は全員、Manager・IS は自分のみ編集可
+        $target = $this->route('user');
+        $auth   = $this->user();
+
+        return $auth?->isAdmin()
+            || $auth?->isManager()
+            || $auth?->id === $target?->id;
+    }
+
+    public function rules(): array
+    {
+        $userId = $this->route('user')?->id;
+
+        return [
+            'name'                  => ['sometimes', 'string', 'max:255'],
+            'username'              => ['sometimes', 'nullable', 'string', 'max:255', "unique:users,username,{$userId}"],
+            'email'                 => ['sometimes', 'string', 'email', 'max:255', "unique:users,email,{$userId}"],
+            'password'              => ['sometimes', 'string', 'min:8'],
+            'role'                  => ['sometimes', 'in:Admin,Manager,IS'],
+            'status'                => ['sometimes', 'in:active,onboarding,inactive'],
+            'join_at'               => ['sometimes', 'nullable', 'date'],
+            'monthly_target_count'  => ['sometimes', 'nullable', 'integer', 'min:0'],
+            'extension_number'      => ['sometimes', 'nullable', 'string', 'max:20'],
+        ];
+    }
+}

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -15,8 +14,14 @@ class User extends Authenticatable
 
     protected $fillable = [
         'name',
+        'username',
         'email',
         'password',
+        'role',
+        'status',
+        'join_at',
+        'monthly_target_count',
+        'extension_number',
     ];
 
     protected $hidden = [
@@ -27,8 +32,25 @@ class User extends Authenticatable
     protected function casts(): array
     {
         return [
-            'email_verified_at' => 'datetime',
-            'password' => 'hashed',
+            'email_verified_at'    => 'datetime',
+            'password'             => 'hashed',
+            'join_at'              => 'date',
+            'monthly_target_count' => 'integer',
         ];
+    }
+
+    public function isAdmin(): bool
+    {
+        return $this->role === 'Admin';
+    }
+
+    public function isManager(): bool
+    {
+        return $this->role === 'Manager';
+    }
+
+    public function isAdminOrManager(): bool
+    {
+        return in_array($this->role, ['Admin', 'Manager']);
     }
 }

--- a/backend/database/migrations/2026_02_21_100000_add_profile_columns_to_users_table.php
+++ b/backend/database/migrations/2026_02_21_100000_add_profile_columns_to_users_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('username')->unique()->nullable()->after('name');
+            $table->enum('role', ['Admin', 'Manager', 'IS'])->default('IS')->after('password');
+            $table->enum('status', ['active', 'onboarding', 'inactive'])->default('onboarding')->after('role');
+            $table->date('join_at')->nullable()->after('status');
+            $table->unsignedInteger('monthly_target_count')->default(0)->after('join_at');
+            $table->string('extension_number')->nullable()->after('monthly_target_count');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['username', 'role', 'status', 'join_at', 'monthly_target_count', 'extension_number']);
+        });
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api\AuthController;
+use App\Http\Controllers\Api\UserController;
 use Illuminate\Support\Facades\Route;
 
 // 認証不要
@@ -10,6 +11,10 @@ Route::post('/guest-login', [AuthController::class, 'guestLogin']);
 
 // 要認証
 Route::middleware('auth:sanctum')->group(function () {
+    // 認証
     Route::post('/logout', [AuthController::class, 'logout']);
     Route::get('/user',    [AuthController::class, 'me']);
+
+    // ユーザー管理
+    Route::apiResource('users', UserController::class);
 });


### PR DESCRIPTION
Backend (Laravel):
- Add migration: role, status, username, join_at, monthly_target_count, extension_number to users table
- Update User model with new fillable fields and role helper methods
- Create UserController with CRUD, search/filter/sort/pagination
- Create StoreUserRequest (Admin only) and UpdateUserRequest (role-aware)
- Add route: apiResource users inside auth:sanctum middleware

Frontend (Next.js):
- Extend lib/api.ts with User type (Role/Status enums), PaginatedResponse, usersApi
- Add /users - list page with search, filter, sort, pagination, delete
- Add /users/[id] - detail page with user info
- Add /users/[id]/edit - edit form (role-based field visibility)
- Add /users/new - create form (Admin only)