### PR TITLE
feat: Phase 5 - リード管理機能（コア機能）の実装

### DIFF
--- a/app/app/leads/[id]/edit/page.tsx
+++ b/app/app/leads/[id]/edit/page.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { useState, useEffect, FormEvent } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { useAuth } from '@/context/AuthContext';
+import { leadsApi, leadStagesApi, customersApi, usersApi, Lead, LeadStage, Customer, User } from '@/lib/api';
+
+export default function EditLeadPage() {
+  const { token, user: me } = useAuth();
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+
+  const [lead, setLead]           = useState<Lead | null>(null);
+  const [stages, setStages]       = useState<LeadStage[]>([]);
+  const [customers, setCustomers] = useState<Customer[]>([]);
+  const [users, setUsers]         = useState<User[]>([]);
+  const [form, setForm] = useState({
+    title: '', customer_id: '', owner_id: '', current_stage_id: '', note: '',
+  });
+  const [errors, setErrors] = useState<Record<string, string[]>>({});
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving]   = useState(false);
+
+  useEffect(() => {
+    if (!token) return;
+    Promise.all([
+      leadsApi.get(token, Number(id)),
+      leadStagesApi.list(token),
+      customersApi.list(token, { per_page: 200 }),
+      usersApi.list(token, { per_page: 200 }),
+    ]).then(([l, s, c, u]) => {
+      setLead(l);
+      setStages(s.filter(st => st.is_active));
+      setCustomers(c.data);
+      setUsers(u.data);
+      setForm({
+        title:            l.title,
+        customer_id:      String(l.customer_id),
+        owner_id:         l.owner_id ? String(l.owner_id) : '',
+        current_stage_id: l.current_stage_id ? String(l.current_stage_id) : '',
+        note:             l.note ?? '',
+      });
+    })
+      .catch(() => router.push('/leads'))
+      .finally(() => setLoading(false));
+  }, [token, id, router]);
+
+  if (me?.role !== 'Admin' && me?.role !== 'Manager') {
+    router.push('/leads');
+    return null;
+  }
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!token) return;
+    setSaving(true);
+    setErrors({});
+    try {
+      await leadsApi.update(token, Number(id), {
+        title:            form.title,
+        customer_id:      Number(form.customer_id),
+        owner_id:         form.owner_id ? Number(form.owner_id) : null,
+        current_stage_id: form.current_stage_id ? Number(form.current_stage_id) : null,
+        note:             form.note || null,
+      });
+      router.push(`/leads/${id}`);
+    } catch (err: unknown) {
+      const e = err as { errors?: Record<string, string[]>; message?: string };
+      setErrors(e.errors ?? { title: [e.message ?? '更新に失敗しました。'] });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const set = (key: keyof typeof form) =>
+    (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) =>
+      setForm(prev => ({ ...prev, [key]: e.target.value }));
+
+  if (loading) return <div className="flex items-center justify-center min-h-screen text-gray-400">読み込み中...</div>;
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-2xl mx-auto p-6">
+        <div className="flex items-center gap-2 text-sm text-gray-500 mb-4">
+          <Link href="/leads" className="hover:text-blue-600">リード管理</Link>
+          <span>/</span>
+          <Link href={`/leads/${id}`} className="hover:text-blue-600">{lead?.title}</Link>
+          <span>/</span>
+          <span className="text-gray-800">編集</span>
+        </div>
+
+        <div className="bg-white rounded-xl shadow-sm p-6">
+          <h1 className="text-xl font-bold text-gray-800 mb-6">リード編集</h1>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">タイトル *</label>
+              <input type="text" required value={form.title} onChange={set('title')}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+              {errors.title && <p className="text-red-500 text-xs mt-1">{errors.title[0]}</p>}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">顧客 *</label>
+              <select required value={form.customer_id} onChange={set('customer_id')}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+                <option value="">選択してください</option>
+                {customers.map(c => <option key={c.id} value={String(c.id)}>{c.name}</option>)}
+              </select>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">担当者</label>
+              <select value={form.owner_id} onChange={set('owner_id')}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+                <option value="">未割り当て</option>
+                {users.map(u => <option key={u.id} value={String(u.id)}>{u.name}</option>)}
+              </select>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">ステージ</label>
+              <select value={form.current_stage_id} onChange={set('current_stage_id')}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+                <option value="">選択してください</option>
+                {stages.map(s => <option key={s.id} value={String(s.id)}>{s.name}</option>)}
+              </select>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">メモ</label>
+              <textarea value={form.note} onChange={set('note')} rows={4}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none" />
+            </div>
+
+            <div className="flex gap-3 pt-2">
+              <button type="submit" disabled={saving}
+                className="bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold px-4 py-2 rounded-lg transition disabled:opacity-50">
+                {saving ? '更新中...' : '更新する'}
+              </button>
+              <button type="button" onClick={() => router.back()}
+                className="border border-gray-300 hover:bg-gray-50 text-gray-700 text-sm font-semibold px-4 py-2 rounded-lg transition">
+                キャンセル
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/app/leads/[id]/page.tsx
+++ b/app/app/leads/[id]/page.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { useAuth } from '@/context/AuthContext';
+import { leadsApi, leadStagesApi, Lead, LeadStage } from '@/lib/api';
+
+function Timeline({ lead }: { lead: Lead }) {
+  const histories = lead.stage_histories ?? [];
+  if (histories.length === 0) {
+    return <p className="text-sm text-gray-400">ステージ変更履歴はありません。</p>;
+  }
+
+  return (
+    <ol className="relative border-l border-gray-200 ml-3">
+      {[...histories].reverse().map(h => (
+        <li key={h.id} className="mb-6 ml-6">
+          <span className="absolute -left-3 flex h-6 w-6 items-center justify-center rounded-full bg-blue-100 ring-8 ring-white">
+            <svg className="h-3 w-3 text-blue-600" fill="currentColor" viewBox="0 0 20 20">
+              <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clipRule="evenodd" />
+            </svg>
+          </span>
+          <div className="rounded-lg border border-gray-100 bg-white p-3 shadow-sm">
+            <div className="flex items-center gap-2 mb-1">
+              {h.from_stage ? (
+                <>
+                  <span className="text-xs px-2 py-0.5 rounded bg-gray-100 text-gray-600">{h.from_stage.name}</span>
+                  <span className="text-gray-400 text-xs">→</span>
+                </>
+              ) : null}
+              <span className="text-xs px-2 py-0.5 rounded bg-blue-100 text-blue-700">{h.to_stage.name}</span>
+            </div>
+            <div className="flex items-center gap-3 text-xs text-gray-500">
+              {h.changed_by_user && <span>変更者: {h.changed_by_user.name}</span>}
+              {h.reason_code && <span>理由: {h.reason_code}</span>}
+              {h.stay_days != null && <span>在留: {h.stay_days}日</span>}
+              <span>{new Date(h.created_at).toLocaleString('ja-JP')}</span>
+            </div>
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+export default function LeadDetailPage() {
+  const { token, user: me } = useAuth();
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+
+  const [lead, setLead]     = useState<Lead | null>(null);
+  const [stages, setStages] = useState<LeadStage[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [transitioning, setTransitioning] = useState(false);
+  const [selectedStage, setSelectedStage] = useState('');
+
+  const canWrite = me?.role === 'Admin' || me?.role === 'Manager';
+
+  useEffect(() => {
+    if (!token) return;
+    Promise.all([
+      leadsApi.get(token, Number(id)),
+      leadStagesApi.list(token),
+    ])
+      .then(([l, s]) => {
+        setLead(l);
+        setStages(s.filter(st => st.is_active));
+        setSelectedStage(String(l.current_stage_id ?? ''));
+      })
+      .catch(() => router.push('/leads'))
+      .finally(() => setLoading(false));
+  }, [token, id, router]);
+
+  const handleTransition = async () => {
+    if (!token || !lead || !selectedStage) return;
+    setTransitioning(true);
+    try {
+      const updated = await leadsApi.transition(token, lead.id, { to_stage_id: Number(selectedStage) });
+      setLead(updated);
+      setSelectedStage(String(updated.current_stage_id ?? ''));
+    } finally {
+      setTransitioning(false);
+    }
+  };
+
+  if (loading) return <div className="flex items-center justify-center min-h-screen text-gray-400">読み込み中...</div>;
+  if (!lead)   return null;
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-3xl mx-auto p-6">
+        {/* パンくず */}
+        <div className="flex items-center gap-2 text-sm text-gray-500 mb-4">
+          <Link href="/leads" className="hover:text-blue-600">リード管理</Link>
+          <span>/</span>
+          <span className="text-gray-800">{lead.title}</span>
+        </div>
+
+        <div className="grid gap-6">
+          {/* 基本情報 */}
+          <div className="bg-white rounded-xl shadow-sm p-6">
+            <div className="flex items-start justify-between mb-4">
+              <div>
+                <h1 className="text-xl font-bold text-gray-800">{lead.title}</h1>
+                <Link href={`/customers/${lead.customer_id}`} className="text-sm text-blue-600 hover:underline mt-0.5 block">
+                  {lead.customer?.name}
+                </Link>
+              </div>
+              {canWrite && (
+                <button onClick={() => router.push(`/leads/${lead.id}/edit`)}
+                  className="bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold px-4 py-2 rounded-lg transition">
+                  編集
+                </button>
+              )}
+            </div>
+
+            <dl className="divide-y divide-gray-100">
+              <div className="flex py-3">
+                <dt className="w-40 text-sm font-medium text-gray-500 shrink-0">現在のステージ</dt>
+                <dd className="text-sm">
+                  {lead.current_stage ? (
+                    <span className="px-2 py-0.5 rounded bg-blue-100 text-blue-700 text-xs font-medium">{lead.current_stage.name}</span>
+                  ) : <span className="text-gray-400">未設定</span>}
+                </dd>
+              </div>
+              <div className="flex py-3">
+                <dt className="w-40 text-sm font-medium text-gray-500 shrink-0">担当者</dt>
+                <dd className="text-sm text-gray-800">{lead.owner?.name ?? '—'}</dd>
+              </div>
+              <div className="flex py-3">
+                <dt className="w-40 text-sm font-medium text-gray-500 shrink-0">最終活動日</dt>
+                <dd className="text-sm text-gray-800">
+                  {lead.last_activity_at ? new Date(lead.last_activity_at).toLocaleString('ja-JP') : '—'}
+                </dd>
+              </div>
+              <div className="flex py-3">
+                <dt className="w-40 text-sm font-medium text-gray-500 shrink-0">タッチ数</dt>
+                <dd className="text-sm text-gray-800">{lead.total_touch_count}</dd>
+              </div>
+              {lead.note && (
+                <div className="flex py-3">
+                  <dt className="w-40 text-sm font-medium text-gray-500 shrink-0">メモ</dt>
+                  <dd className="text-sm text-gray-800 whitespace-pre-wrap">{lead.note}</dd>
+                </div>
+              )}
+            </dl>
+          </div>
+
+          {/* ステージ遷移 */}
+          <div className="bg-white rounded-xl shadow-sm p-6">
+            <h2 className="text-base font-semibold text-gray-800 mb-4">ステージ変更</h2>
+            <div className="flex gap-3 items-center">
+              <select value={selectedStage} onChange={e => setSelectedStage(e.target.value)}
+                className="border border-gray-300 rounded-lg px-3 py-2 text-sm flex-1 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                <option value="">ステージを選択</option>
+                {stages.map(s => (
+                  <option key={s.id} value={String(s.id)}>{s.name}</option>
+                ))}
+              </select>
+              <button
+                onClick={handleTransition}
+                disabled={!selectedStage || String(lead.current_stage_id) === selectedStage || transitioning}
+                className="bg-blue-600 hover:bg-blue-700 disabled:opacity-40 text-white text-sm font-semibold px-4 py-2 rounded-lg transition">
+                {transitioning ? '変更中...' : '変更する'}
+              </button>
+            </div>
+          </div>
+
+          {/* 履歴タイムライン */}
+          <div className="bg-white rounded-xl shadow-sm p-6">
+            <h2 className="text-base font-semibold text-gray-800 mb-4">ステージ変更履歴</h2>
+            <Timeline lead={lead} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/app/leads/new/page.tsx
+++ b/app/app/leads/new/page.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useState, useEffect, FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { useAuth } from '@/context/AuthContext';
+import { leadsApi, leadStagesApi, customersApi, usersApi, LeadStage, Customer, User } from '@/lib/api';
+
+export default function NewLeadPage() {
+  const { token, user: me } = useAuth();
+  const router = useRouter();
+
+  const [form, setForm] = useState({
+    title: '',
+    customer_id: '',
+    owner_id: '',
+    current_stage_id: '',
+    note: '',
+  });
+  const [stages, setStages]       = useState<LeadStage[]>([]);
+  const [customers, setCustomers] = useState<Customer[]>([]);
+  const [users, setUsers]         = useState<User[]>([]);
+  const [errors, setErrors]       = useState<Record<string, string[]>>({});
+  const [saving, setSaving]       = useState(false);
+
+  if (me?.role !== 'Admin' && me?.role !== 'Manager') {
+    router.push('/leads');
+    return null;
+  }
+
+  useEffect(() => {
+    if (!token) return;
+    Promise.all([
+      leadStagesApi.list(token),
+      customersApi.list(token, { per_page: 200 }),
+      usersApi.list(token, { per_page: 200 }),
+    ]).then(([s, c, u]) => {
+      setStages(s.filter(st => st.is_active));
+      setCustomers(c.data);
+      setUsers(u.data);
+    });
+  }, [token]);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!token) return;
+    setSaving(true);
+    setErrors({});
+    try {
+      const created = await leadsApi.create(token, {
+        title:            form.title,
+        customer_id:      Number(form.customer_id),
+        owner_id:         form.owner_id ? Number(form.owner_id) : null,
+        current_stage_id: form.current_stage_id ? Number(form.current_stage_id) : null,
+        note:             form.note || null,
+      });
+      router.push(`/leads/${created.id}`);
+    } catch (err: unknown) {
+      const e = err as { errors?: Record<string, string[]>; message?: string };
+      setErrors(e.errors ?? { title: [e.message ?? '作成に失敗しました。'] });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const set = (key: keyof typeof form) =>
+    (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) =>
+      setForm(prev => ({ ...prev, [key]: e.target.value }));
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-2xl mx-auto p-6">
+        <div className="flex items-center gap-2 text-sm text-gray-500 mb-4">
+          <Link href="/leads" className="hover:text-blue-600">リード管理</Link>
+          <span>/</span>
+          <span className="text-gray-800">新規追加</span>
+        </div>
+
+        <div className="bg-white rounded-xl shadow-sm p-6">
+          <h1 className="text-xl font-bold text-gray-800 mb-6">リード追加</h1>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">タイトル *</label>
+              <input type="text" required value={form.title} onChange={set('title')}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+              {errors.title && <p className="text-red-500 text-xs mt-1">{errors.title[0]}</p>}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">顧客 *</label>
+              <select required value={form.customer_id} onChange={set('customer_id')}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+                <option value="">選択してください</option>
+                {customers.map(c => <option key={c.id} value={String(c.id)}>{c.name}</option>)}
+              </select>
+              {errors.customer_id && <p className="text-red-500 text-xs mt-1">{errors.customer_id[0]}</p>}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">担当者</label>
+              <select value={form.owner_id} onChange={set('owner_id')}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+                <option value="">未割り当て</option>
+                {users.map(u => <option key={u.id} value={String(u.id)}>{u.name}</option>)}
+              </select>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">初期ステージ</label>
+              <select value={form.current_stage_id} onChange={set('current_stage_id')}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+                <option value="">選択してください</option>
+                {stages.map(s => <option key={s.id} value={String(s.id)}>{s.name}</option>)}
+              </select>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">メモ</label>
+              <textarea value={form.note} onChange={set('note')} rows={4}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none" />
+            </div>
+
+            <div className="flex gap-3 pt-2">
+              <button type="submit" disabled={saving}
+                className="bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold px-4 py-2 rounded-lg transition disabled:opacity-50">
+                {saving ? '作成中...' : '追加する'}
+              </button>
+              <button type="button" onClick={() => router.push('/leads')}
+                className="border border-gray-300 hover:bg-gray-50 text-gray-700 text-sm font-semibold px-4 py-2 rounded-lg transition">
+                キャンセル
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/app/leads/page.tsx
+++ b/app/app/leads/page.tsx
@@ -1,0 +1,247 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/context/AuthContext';
+import { leadsApi, leadStagesApi, Lead, LeadStage, LeadParams } from '@/lib/api';
+
+const STAGE_COLORS = [
+  'border-gray-300 bg-gray-50',
+  'border-blue-300 bg-blue-50',
+  'border-yellow-300 bg-yellow-50',
+  'border-orange-300 bg-orange-50',
+  'border-purple-300 bg-purple-50',
+  'border-green-300 bg-green-50',
+  'border-red-300 bg-red-50',
+];
+
+export default function LeadsPage() {
+  const { token, user: me } = useAuth();
+  const router = useRouter();
+
+  const [leads, setLeads]   = useState<Lead[]>([]);
+  const [stages, setStages] = useState<LeadStage[]>([]);
+  const [total, setTotal]   = useState(0);
+  const [loading, setLoading] = useState(false);
+
+  const [search,  setSearch]  = useState('');
+  const [ownerId, setOwnerId] = useState('');
+  const [viewMode, setViewMode] = useState<'kanban' | 'list'>('kanban');
+
+  const canWrite = me?.role === 'Admin' || me?.role === 'Manager';
+
+  const fetchAll = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    try {
+      const [stagesRes, leadsRes] = await Promise.all([
+        leadStagesApi.list(token),
+        leadsApi.list(token, {
+          search: search || undefined,
+          owner_id: ownerId ? Number(ownerId) : undefined,
+          per_page: 200,
+        } as LeadParams),
+      ]);
+      setStages(stagesRes.filter(s => s.is_active));
+      setLeads(leadsRes.data);
+      setTotal(leadsRes.total);
+    } finally {
+      setLoading(false);
+    }
+  }, [token, search, ownerId]);
+
+  useEffect(() => { fetchAll(); }, [fetchAll]);
+
+  const handleDelete = async (id: number) => {
+    if (!token || !confirm('このリードを削除しますか？')) return;
+    await leadsApi.delete(token, id);
+    fetchAll();
+  };
+
+  const leadsByStage = (stageId: number | null) =>
+    leads.filter(l => l.current_stage_id === stageId);
+
+  const unassignedLeads = leads.filter(l => l.current_stage_id === null);
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-full mx-auto p-6">
+        {/* ヘッダー */}
+        <div className="flex items-center justify-between mb-6">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-800">リード管理</h1>
+            <p className="text-sm text-gray-500 mt-1">全 {total} 件</p>
+          </div>
+          <div className="flex items-center gap-3">
+            <div className="flex rounded-lg border border-gray-300 overflow-hidden">
+              <button onClick={() => setViewMode('kanban')}
+                className={`px-3 py-1.5 text-sm ${viewMode === 'kanban' ? 'bg-blue-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}>
+                カンバン
+              </button>
+              <button onClick={() => setViewMode('list')}
+                className={`px-3 py-1.5 text-sm ${viewMode === 'list' ? 'bg-blue-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}>
+                リスト
+              </button>
+            </div>
+            {canWrite && (
+              <Link href="/leads/new"
+                className="bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold px-4 py-2 rounded-lg transition">
+                + リード追加
+              </Link>
+            )}
+          </div>
+        </div>
+
+        {/* フィルター */}
+        <div className="bg-white rounded-xl shadow-sm p-4 mb-4 flex flex-wrap gap-3">
+          <input type="text" placeholder="タイトル・会社名で検索" value={search}
+            onChange={e => setSearch(e.target.value)}
+            className="border border-gray-300 rounded-lg px-3 py-2 text-sm flex-1 min-w-48 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+          <input type="number" placeholder="担当者ID" value={ownerId}
+            onChange={e => setOwnerId(e.target.value)}
+            className="border border-gray-300 rounded-lg px-3 py-2 text-sm w-36 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+        </div>
+
+        {loading ? (
+          <div className="flex items-center justify-center py-20 text-gray-400">読み込み中...</div>
+        ) : viewMode === 'kanban' ? (
+          /* カンバンビュー */
+          <div className="flex gap-4 overflow-x-auto pb-4">
+            {stages.map((stage, idx) => {
+              const stageLeads = leadsByStage(stage.id);
+              const color = STAGE_COLORS[idx % STAGE_COLORS.length];
+              return (
+                <div key={stage.id} className={`flex-shrink-0 w-72 rounded-xl border-2 ${color} flex flex-col`}>
+                  <div className="p-3 border-b border-inherit">
+                    <div className="flex items-center justify-between">
+                      <span className="font-semibold text-sm text-gray-700">{stage.name}</span>
+                      <span className="text-xs bg-white rounded-full px-2 py-0.5 text-gray-500 border border-gray-200">{stageLeads.length}</span>
+                    </div>
+                  </div>
+                  <div className="p-3 flex flex-col gap-2 flex-1 overflow-y-auto max-h-[calc(100vh-280px)]">
+                    {stageLeads.map(lead => (
+                      <LeadCard key={lead.id} lead={lead} canWrite={canWrite}
+                        isAdmin={me?.role === 'Admin'}
+                        onDetail={() => router.push(`/leads/${lead.id}`)}
+                        onEdit={() => router.push(`/leads/${lead.id}/edit`)}
+                        onDelete={() => handleDelete(lead.id)} />
+                    ))}
+                    {stageLeads.length === 0 && (
+                      <p className="text-xs text-gray-400 text-center py-4">リードなし</p>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+            {unassignedLeads.length > 0 && (
+              <div className="flex-shrink-0 w-72 rounded-xl border-2 border-dashed border-gray-300 bg-white flex flex-col">
+                <div className="p-3 border-b border-gray-200">
+                  <div className="flex items-center justify-between">
+                    <span className="font-semibold text-sm text-gray-500">未割り当て</span>
+                    <span className="text-xs bg-gray-100 rounded-full px-2 py-0.5 text-gray-500">{unassignedLeads.length}</span>
+                  </div>
+                </div>
+                <div className="p-3 flex flex-col gap-2 overflow-y-auto max-h-[calc(100vh-280px)]">
+                  {unassignedLeads.map(lead => (
+                    <LeadCard key={lead.id} lead={lead} canWrite={canWrite}
+                      isAdmin={me?.role === 'Admin'}
+                      onDetail={() => router.push(`/leads/${lead.id}`)}
+                      onEdit={() => router.push(`/leads/${lead.id}/edit`)}
+                      onDelete={() => handleDelete(lead.id)} />
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        ) : (
+          /* リストビュー */
+          <div className="bg-white rounded-xl shadow-sm overflow-hidden">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50 border-b border-gray-200">
+                <tr>
+                  <th className="px-4 py-3 text-left font-semibold text-gray-600">タイトル</th>
+                  <th className="px-4 py-3 text-left font-semibold text-gray-600">顧客</th>
+                  <th className="px-4 py-3 text-left font-semibold text-gray-600">ステージ</th>
+                  <th className="px-4 py-3 text-left font-semibold text-gray-600">担当者</th>
+                  <th className="px-4 py-3 text-left font-semibold text-gray-600">最終活動</th>
+                  <th className="px-4 py-3 text-left font-semibold text-gray-600">操作</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {leads.length === 0 ? (
+                  <tr><td colSpan={6} className="px-4 py-8 text-center text-gray-400">リードが見つかりません</td></tr>
+                ) : leads.map(lead => (
+                  <tr key={lead.id} className="hover:bg-gray-50 transition">
+                    <td className="px-4 py-3">
+                      <div className="font-medium text-gray-800">{lead.title}</div>
+                    </td>
+                    <td className="px-4 py-3 text-gray-600 text-xs">{lead.customer?.name ?? '—'}</td>
+                    <td className="px-4 py-3">
+                      {lead.current_stage ? (
+                        <span className="text-xs px-2 py-0.5 rounded bg-blue-100 text-blue-700">{lead.current_stage.name}</span>
+                      ) : <span className="text-gray-400 text-xs">—</span>}
+                    </td>
+                    <td className="px-4 py-3 text-gray-600 text-xs">{lead.owner?.name ?? '—'}</td>
+                    <td className="px-4 py-3 text-gray-500 text-xs">
+                      {lead.last_activity_at ? new Date(lead.last_activity_at).toLocaleDateString('ja-JP') : '—'}
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex gap-2">
+                        <button onClick={() => router.push(`/leads/${lead.id}`)}
+                          className="text-blue-600 hover:underline text-xs">詳細</button>
+                        {canWrite && (
+                          <button onClick={() => router.push(`/leads/${lead.id}/edit`)}
+                            className="text-gray-600 hover:underline text-xs">編集</button>
+                        )}
+                        {me?.role === 'Admin' && (
+                          <button onClick={() => handleDelete(lead.id)}
+                            className="text-red-500 hover:underline text-xs">削除</button>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+type LeadCardProps = {
+  lead: Lead;
+  canWrite: boolean;
+  isAdmin: boolean;
+  onDetail: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+};
+
+function LeadCard({ lead, canWrite, isAdmin, onDetail, onEdit, onDelete }: LeadCardProps) {
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-3 shadow-sm hover:shadow-md transition cursor-pointer"
+      onClick={onDetail}>
+      <div className="font-medium text-sm text-gray-800 mb-1 line-clamp-2">{lead.title}</div>
+      <div className="text-xs text-gray-500 mb-2">{lead.customer?.name}</div>
+      {lead.owner && (
+        <div className="text-xs text-gray-400">担当: {lead.owner.name}</div>
+      )}
+      {lead.last_activity_at && (
+        <div className="text-xs text-gray-400 mt-1">
+          {new Date(lead.last_activity_at).toLocaleDateString('ja-JP')}
+        </div>
+      )}
+      <div className="flex gap-2 mt-2 pt-2 border-t border-gray-100" onClick={e => e.stopPropagation()}>
+        {canWrite && (
+          <button onClick={onEdit} className="text-xs text-gray-500 hover:text-gray-700">編集</button>
+        )}
+        {isAdmin && (
+          <button onClick={onDelete} className="text-xs text-red-400 hover:text-red-600">削除</button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -132,6 +132,59 @@ export const usersApi = {
     request<{ message: string }>(`/users/${id}`, { method: 'DELETE', token }),
 };
 
+// ---- リード管理 型定義 ----
+export type LeadStage = {
+  id: number;
+  name: string;
+  display_order: number;
+  is_active: boolean;
+  reassignment_threshold_days: number | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type LeadStageHistory = {
+  id: number;
+  lead_id: number;
+  from_stage_id: number | null;
+  to_stage_id: number;
+  changed_by: number | null;
+  reason_code: string | null;
+  stay_days: number | null;
+  created_at: string;
+  from_stage: LeadStage | null;
+  to_stage: LeadStage;
+  changed_by_user: User | null;
+};
+
+export type Lead = {
+  id: number;
+  customer_id: number;
+  owner_id: number | null;
+  current_stage_id: number | null;
+  title: string;
+  note: string | null;
+  last_activity_at: string | null;
+  stage_updated_at: string | null;
+  total_touch_count: number;
+  created_at: string;
+  customer: Customer;
+  owner: User | null;
+  current_stage: LeadStage | null;
+  stage_histories?: LeadStageHistory[];
+};
+
+export type LeadParams = {
+  search?: string;
+  stage_id?: number;
+  owner_id?: number;
+  customer_id?: number;
+  sort_by?: string;
+  sort_dir?: 'asc' | 'desc';
+  per_page?: number;
+  page?: number;
+};
+
 // ---- 顧客管理 API ----
 export const customersApi = {
   list: (token: string, params: CustomerParams = {}) => {
@@ -150,4 +203,42 @@ export const customersApi = {
     request<Customer>(`/customers/${id}`, { method: 'PUT', body: data, token }),
   delete: (token: string, id: number) =>
     request<{ message: string }>(`/customers/${id}`, { method: 'DELETE', token }),
+};
+
+// ---- リードステージ API ----
+export const leadStagesApi = {
+  list: (token: string) =>
+    request<LeadStage[]>('/lead-stages', { token }),
+  get: (token: string, id: number) =>
+    request<LeadStage>(`/lead-stages/${id}`, { token }),
+  create: (token: string, data: Omit<LeadStage, 'id' | 'created_at' | 'updated_at'>) =>
+    request<LeadStage>('/lead-stages', { method: 'POST', body: data, token }),
+  update: (token: string, id: number, data: Partial<Omit<LeadStage, 'id' | 'created_at' | 'updated_at'>>) =>
+    request<LeadStage>(`/lead-stages/${id}`, { method: 'PUT', body: data, token }),
+  delete: (token: string, id: number) =>
+    request<{ message: string }>(`/lead-stages/${id}`, { method: 'DELETE', token }),
+};
+
+// ---- リード管理 API ----
+export const leadsApi = {
+  list: (token: string, params: LeadParams = {}) => {
+    const qs = new URLSearchParams(
+      Object.entries(params)
+        .filter(([, v]) => v !== undefined && v !== '')
+        .map(([k, v]) => [k, String(v)])
+    ).toString();
+    return request<PaginatedResponse<Lead>>(`/leads${qs ? '?' + qs : ''}`, { token });
+  },
+  get: (token: string, id: number) =>
+    request<Lead>(`/leads/${id}`, { token }),
+  create: (token: string, data: { customer_id: number; title: string; owner_id?: number | null; current_stage_id?: number | null; note?: string | null }) =>
+    request<Lead>('/leads', { method: 'POST', body: data, token }),
+  update: (token: string, id: number, data: Partial<{ customer_id: number; title: string; owner_id: number | null; current_stage_id: number | null; note: string | null }>) =>
+    request<Lead>(`/leads/${id}`, { method: 'PUT', body: data, token }),
+  delete: (token: string, id: number) =>
+    request<{ message: string }>(`/leads/${id}`, { method: 'DELETE', token }),
+  transition: (token: string, id: number, data: { to_stage_id: number; reason_code?: string }) =>
+    request<Lead>(`/leads/${id}/transition`, { method: 'POST', body: data, token }),
+  assign: (token: string, id: number, owner_id: number | null) =>
+    request<Lead>(`/leads/${id}/assign`, { method: 'PATCH', body: { owner_id }, token }),
 };

--- a/backend/app/Http/Controllers/Api/LeadController.php
+++ b/backend/app/Http/Controllers/Api/LeadController.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Lead\StoreLeadRequest;
+use App\Http\Requests\Lead\UpdateLeadRequest;
+use App\Http\Requests\Lead\TransitionLeadRequest;
+use App\Models\Lead;
+use App\Models\LeadStageHistory;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class LeadController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $query = Lead::with(['customer', 'owner', 'currentStage']);
+
+        if ($search = $request->query('search')) {
+            $query->whereHas('customer', fn ($q) => $q->where('name', 'like', "%{$search}%"))
+                  ->orWhere('title', 'like', "%{$search}%");
+        }
+
+        if ($stageId = $request->query('stage_id')) {
+            $query->where('current_stage_id', $stageId);
+        }
+
+        if ($ownerId = $request->query('owner_id')) {
+            $query->where('owner_id', $ownerId);
+        }
+
+        if ($customerId = $request->query('customer_id')) {
+            $query->where('customer_id', $customerId);
+        }
+
+        $allowedSorts = ['created_at', 'last_activity_at', 'stage_updated_at', 'title'];
+        $sortBy  = in_array($request->query('sort_by'), $allowedSorts) ? $request->query('sort_by') : 'created_at';
+        $sortDir = $request->query('sort_dir') === 'asc' ? 'asc' : 'desc';
+
+        $perPage = min((int) ($request->query('per_page', 20)), 100);
+
+        $result = $query->orderBy($sortBy, $sortDir)->paginate($perPage);
+
+        return response()->json($result);
+    }
+
+    public function store(StoreLeadRequest $request): JsonResponse
+    {
+        $lead = DB::transaction(function () use ($request) {
+            $lead = Lead::create(array_merge($request->validated(), [
+                'last_activity_at' => now(),
+                'stage_updated_at' => $request->current_stage_id ? now() : null,
+            ]));
+
+            if ($lead->current_stage_id) {
+                LeadStageHistory::create([
+                    'lead_id'      => $lead->id,
+                    'from_stage_id' => null,
+                    'to_stage_id'  => $lead->current_stage_id,
+                    'changed_by'   => $request->user()->id,
+                    'reason_code'  => 'created',
+                    'stay_days'    => null,
+                ]);
+            }
+
+            return $lead->load(['customer', 'owner', 'currentStage']);
+        });
+
+        return response()->json($lead, 201);
+    }
+
+    public function show(Lead $lead): JsonResponse
+    {
+        return response()->json(
+            $lead->load(['customer', 'owner', 'currentStage', 'stageHistories.fromStage', 'stageHistories.toStage', 'stageHistories.changedByUser'])
+        );
+    }
+
+    public function update(UpdateLeadRequest $request, Lead $lead): JsonResponse
+    {
+        $lead->update($request->validated());
+        return response()->json($lead->load(['customer', 'owner', 'currentStage']));
+    }
+
+    public function destroy(Lead $lead): JsonResponse
+    {
+        if (!request()->user()->isAdmin()) {
+            return response()->json(['message' => '削除権限がありません。'], 403);
+        }
+
+        $lead->delete();
+        return response()->json(['message' => 'リードを削除しました。']);
+    }
+
+    public function transition(TransitionLeadRequest $request, Lead $lead): JsonResponse
+    {
+        $toStageId   = $request->to_stage_id;
+        $fromStageId = $lead->current_stage_id;
+
+        if ($fromStageId === $toStageId) {
+            return response()->json(['message' => '同じステージへの遷移はできません。'], 422);
+        }
+
+        DB::transaction(function () use ($lead, $fromStageId, $toStageId, $request) {
+            $stayDays = null;
+            if ($lead->stage_updated_at) {
+                $stayDays = (int) $lead->stage_updated_at->diffInDays(now());
+            }
+
+            LeadStageHistory::create([
+                'lead_id'       => $lead->id,
+                'from_stage_id' => $fromStageId,
+                'to_stage_id'   => $toStageId,
+                'changed_by'    => $request->user()->id,
+                'reason_code'   => $request->reason_code,
+                'stay_days'     => $stayDays,
+            ]);
+
+            $lead->update([
+                'current_stage_id' => $toStageId,
+                'stage_updated_at' => now(),
+                'last_activity_at' => now(),
+            ]);
+        });
+
+        return response()->json($lead->load(['customer', 'owner', 'currentStage', 'stageHistories.fromStage', 'stageHistories.toStage', 'stageHistories.changedByUser']));
+    }
+
+    public function assign(Request $request, Lead $lead): JsonResponse
+    {
+        if (!$request->user()->isAdminOrManager()) {
+            return response()->json(['message' => '担当者変更の権限がありません。'], 403);
+        }
+
+        $request->validate([
+            'owner_id' => ['nullable', 'integer', 'exists:users,id'],
+        ]);
+
+        $lead->update([
+            'owner_id'         => $request->owner_id,
+            'last_activity_at' => now(),
+        ]);
+
+        return response()->json($lead->load(['customer', 'owner', 'currentStage']));
+    }
+}

--- a/backend/app/Http/Controllers/Api/LeadStageController.php
+++ b/backend/app/Http/Controllers/Api/LeadStageController.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\LeadStage;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class LeadStageController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        $stages = LeadStage::orderBy('display_order')->get();
+        return response()->json($stages);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        if (!$request->user()->isAdmin()) {
+            return response()->json(['message' => 'Adminのみ操作できます。'], 403);
+        }
+
+        $data = $request->validate([
+            'name'                         => ['required', 'string', 'max:100'],
+            'display_order'                => ['required', 'integer', 'min:0'],
+            'is_active'                    => ['boolean'],
+            'reassignment_threshold_days'  => ['nullable', 'integer', 'min:1'],
+        ]);
+
+        $stage = LeadStage::create($data);
+        return response()->json($stage, 201);
+    }
+
+    public function show(LeadStage $leadStage): JsonResponse
+    {
+        return response()->json($leadStage);
+    }
+
+    public function update(Request $request, LeadStage $leadStage): JsonResponse
+    {
+        if (!$request->user()->isAdmin()) {
+            return response()->json(['message' => 'Adminのみ操作できます。'], 403);
+        }
+
+        $data = $request->validate([
+            'name'                         => ['sometimes', 'required', 'string', 'max:100'],
+            'display_order'                => ['sometimes', 'integer', 'min:0'],
+            'is_active'                    => ['boolean'],
+            'reassignment_threshold_days'  => ['nullable', 'integer', 'min:1'],
+        ]);
+
+        $leadStage->update($data);
+        return response()->json($leadStage);
+    }
+
+    public function destroy(Request $request, LeadStage $leadStage): JsonResponse
+    {
+        if (!$request->user()->isAdmin()) {
+            return response()->json(['message' => 'Adminのみ操作できます。'], 403);
+        }
+
+        if ($leadStage->leads()->exists()) {
+            return response()->json(['message' => 'このステージに紐づくリードが存在するため削除できません。'], 422);
+        }
+
+        $leadStage->delete();
+        return response()->json(['message' => 'ステージを削除しました。']);
+    }
+}

--- a/backend/app/Http/Requests/Lead/StoreLeadRequest.php
+++ b/backend/app/Http/Requests/Lead/StoreLeadRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\Lead;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreLeadRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()->isAdminOrManager();
+    }
+
+    public function rules(): array
+    {
+        return [
+            'customer_id'      => ['required', 'integer', 'exists:customers,id'],
+            'owner_id'         => ['nullable', 'integer', 'exists:users,id'],
+            'current_stage_id' => ['nullable', 'integer', 'exists:lead_stages,id'],
+            'title'            => ['required', 'string', 'max:255'],
+            'note'             => ['nullable', 'string'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'customer_id.required' => '顧客は必須です。',
+            'customer_id.exists'   => '顧客が存在しません。',
+            'title.required'       => 'タイトルは必須です。',
+            'title.max'            => 'タイトルは255文字以内で入力してください。',
+        ];
+    }
+}

--- a/backend/app/Http/Requests/Lead/TransitionLeadRequest.php
+++ b/backend/app/Http/Requests/Lead/TransitionLeadRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests\Lead;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TransitionLeadRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'to_stage_id'  => ['required', 'integer', 'exists:lead_stages,id'],
+            'reason_code'  => ['nullable', 'string', 'max:100'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'to_stage_id.required' => '遷移先ステージは必須です。',
+            'to_stage_id.exists'   => '指定されたステージが存在しません。',
+        ];
+    }
+}

--- a/backend/app/Http/Requests/Lead/UpdateLeadRequest.php
+++ b/backend/app/Http/Requests/Lead/UpdateLeadRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests\Lead;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateLeadRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()->isAdminOrManager();
+    }
+
+    public function rules(): array
+    {
+        return [
+            'customer_id'      => ['sometimes', 'integer', 'exists:customers,id'],
+            'owner_id'         => ['nullable', 'integer', 'exists:users,id'],
+            'current_stage_id' => ['nullable', 'integer', 'exists:lead_stages,id'],
+            'title'            => ['sometimes', 'required', 'string', 'max:255'],
+            'note'             => ['nullable', 'string'],
+        ];
+    }
+}

--- a/backend/app/Models/Lead.php
+++ b/backend/app/Models/Lead.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Lead extends Model
+{
+    protected $fillable = [
+        'customer_id',
+        'owner_id',
+        'current_stage_id',
+        'title',
+        'note',
+        'last_activity_at',
+        'stage_updated_at',
+        'total_touch_count',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'last_activity_at' => 'datetime',
+            'stage_updated_at' => 'datetime',
+        ];
+    }
+
+    public function customer(): BelongsTo
+    {
+        return $this->belongsTo(Customer::class);
+    }
+
+    public function owner(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'owner_id');
+    }
+
+    public function currentStage(): BelongsTo
+    {
+        return $this->belongsTo(LeadStage::class, 'current_stage_id');
+    }
+
+    public function stageHistories(): HasMany
+    {
+        return $this->hasMany(LeadStageHistory::class);
+    }
+}

--- a/backend/app/Models/LeadStage.php
+++ b/backend/app/Models/LeadStage.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class LeadStage extends Model
+{
+    protected $fillable = [
+        'name',
+        'display_order',
+        'is_active',
+        'reassignment_threshold_days',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'is_active' => 'boolean',
+        ];
+    }
+
+    public function leads(): HasMany
+    {
+        return $this->hasMany(Lead::class, 'current_stage_id');
+    }
+}

--- a/backend/app/Models/LeadStageHistory.php
+++ b/backend/app/Models/LeadStageHistory.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class LeadStageHistory extends Model
+{
+    protected $fillable = [
+        'lead_id',
+        'from_stage_id',
+        'to_stage_id',
+        'changed_by',
+        'reason_code',
+        'stay_days',
+    ];
+
+    public function lead(): BelongsTo
+    {
+        return $this->belongsTo(Lead::class);
+    }
+
+    public function fromStage(): BelongsTo
+    {
+        return $this->belongsTo(LeadStage::class, 'from_stage_id');
+    }
+
+    public function toStage(): BelongsTo
+    {
+        return $this->belongsTo(LeadStage::class, 'to_stage_id');
+    }
+
+    public function changedByUser(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'changed_by');
+    }
+}

--- a/backend/database/migrations/2026_02_21_120000_create_lead_stages_table.php
+++ b/backend/database/migrations/2026_02_21_120000_create_lead_stages_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('lead_stages', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->integer('display_order')->default(0);
+            $table->boolean('is_active')->default(true);
+            $table->integer('reassignment_threshold_days')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('lead_stages');
+    }
+};

--- a/backend/database/migrations/2026_02_21_120001_create_leads_table.php
+++ b/backend/database/migrations/2026_02_21_120001_create_leads_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('leads', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('customer_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('owner_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->foreignId('current_stage_id')->nullable()->constrained('lead_stages')->nullOnDelete();
+            $table->string('title');
+            $table->text('note')->nullable();
+            $table->timestamp('last_activity_at')->nullable();
+            $table->timestamp('stage_updated_at')->nullable();
+            $table->integer('total_touch_count')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('leads');
+    }
+};

--- a/backend/database/migrations/2026_02_21_120002_create_lead_stage_histories_table.php
+++ b/backend/database/migrations/2026_02_21_120002_create_lead_stage_histories_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('lead_stage_histories', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('lead_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('from_stage_id')->nullable()->constrained('lead_stages')->nullOnDelete();
+            $table->foreignId('to_stage_id')->constrained('lead_stages')->nullOnDelete();
+            $table->foreignId('changed_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('reason_code')->nullable();
+            $table->integer('stay_days')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('lead_stage_histories');
+    }
+};

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -12,6 +12,7 @@ class DatabaseSeeder extends Seeder
     {
         $this->call([
             GuestUserSeeder::class,
+            LeadStageSeeder::class,
         ]);
     }
 }

--- a/backend/database/seeders/LeadStageSeeder.php
+++ b/backend/database/seeders/LeadStageSeeder.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class LeadStageSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $stages = [
+            ['name' => 'アプローチ前',     'display_order' => 1, 'is_active' => true, 'reassignment_threshold_days' => 30],
+            ['name' => 'アプローチ中',     'display_order' => 2, 'is_active' => true, 'reassignment_threshold_days' => 14],
+            ['name' => '商談設定済み',     'display_order' => 3, 'is_active' => true, 'reassignment_threshold_days' => 7],
+            ['name' => '商談中',           'display_order' => 4, 'is_active' => true, 'reassignment_threshold_days' => 14],
+            ['name' => '提案済み',         'display_order' => 5, 'is_active' => true, 'reassignment_threshold_days' => 21],
+            ['name' => 'クローズ（成約）', 'display_order' => 6, 'is_active' => true, 'reassignment_threshold_days' => null],
+            ['name' => 'クローズ（失注）', 'display_order' => 7, 'is_active' => true, 'reassignment_threshold_days' => null],
+        ];
+
+        foreach ($stages as $stage) {
+            DB::table('lead_stages')->insertOrIgnore(array_merge($stage, [
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]));
+        }
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -2,6 +2,8 @@
 
 use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Api\CustomerController;
+use App\Http\Controllers\Api\LeadController;
+use App\Http\Controllers\Api\LeadStageController;
 use App\Http\Controllers\Api\UserController;
 use Illuminate\Support\Facades\Route;
 
@@ -21,4 +23,12 @@ Route::middleware('auth:sanctum')->group(function () {
 
     // 顧客管理
     Route::apiResource('customers', CustomerController::class);
+
+    // リード管理
+    Route::apiResource('leads', LeadController::class);
+    Route::post('leads/{lead}/transition', [LeadController::class, 'transition']);
+    Route::patch('leads/{lead}/assign',    [LeadController::class, 'assign']);
+
+    // リードステージ管理
+    Route::apiResource('lead-stages', LeadStageController::class);
 });


### PR DESCRIPTION
Backend:
- lead_stages, leads, lead_stage_histories マイグレーション作成
- LeadStageSeeder: 初期7ステージ（アプローチ前〜クローズ）
- LeadStage / Lead / LeadStageHistory モデル（リレーション定義）
- LeadController: CRUD + ステージ遷移(transition) + 担当者変更(assign)
- LeadStageController: 管理者向けCRUD
- StoreLead / UpdateLead / TransitionLead FormRequest
- API routes: /leads, /leads/{id}/transition, /leads/{id}/assign, /lead-stages

Frontend:
- lib/api.ts: LeadStage / Lead / LeadStageHistory 型定義、leadsApi / leadStagesApi 追加
- /leads: カンバン・リスト切替ビュー
- /leads/[id]: 詳細 + ステージ遷移 + 履歴タイムライン
- /leads/new: リード作成フォーム
- /leads/[id]/edit: リード編集フォーム